### PR TITLE
Fixes ENYO-1501

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,6 +7,9 @@ var
 	assert = require('assert');
 
 var
+	slash = require('slash');
+
+var
 	logger = require('./logger');
 
 exports.createStyleNode = createStyleNode;
@@ -163,7 +166,7 @@ function translateImportPaths (text, base, file) {
 			if (src.charAt(0) != '/') {
 				ret = '@import \'' + (
 						// we simply convert the relative path to the actual path
-						path.join(base, src)
+						slash(path.join(base, src))
 					) + '\'';
 				logger.log('debug', '-- %s -> translating @import from "%s" to "%s"', file, match, ret);
 				return ret;
@@ -183,7 +186,7 @@ function translateUrlPaths (text, base, origin, pkg, file, assets) {
 			if (exact.charAt(0) != '/') {
 				rel = path.relative(pkg, path.resolve(origin, exact));
 				ret = 'url(\'' + (
-					(uri = path.join(base, rel))
+					(uri = slash(path.join(base, rel)))
 					) + '\')';
 				logger.log('debug', '-- %s -> translating URL from "%s" to "%s"', file, match, ret);
 				assets[uri] = file;


### PR DESCRIPTION
## Issue
When using path.join(), the \ isn't properly escaped with \\.

## Fix
Always use posix paths when rewriting CSS contents.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)