### PR TITLE
Fixes ENYO-1514

### DIFF
--- a/lib/Packager/index.js
+++ b/lib/Packager/index.js
@@ -220,21 +220,25 @@ Packager.prototype.setupBundle = function (bundle) {
 	
 	
 	var
-		transform = rewriter(this),
-		packager = this,
-		plugin = function (bundle) {
-			bundle.pipeline.get('sort').push(sorter(packager));
-		};
+		transform = rewriter(this);
 
 	bundle
 		.transform(transform)
-		.plugin(plugin)
 		.add(this.main)
 		.on('dep', function (row) {
 			this.emit('file', row.file)
 		}.bind(this));
 
-	return bundle
+	return bundle;
+};
+
+Packager.prototype.applySorter = function (bundle) {
+	var packager = this;
+	bundle.plugin(function (bundle) {
+		bundle.pipeline.get('sort').push(sorter(packager));
+	});
+
+	return bundle;
 };
 
 /**
@@ -272,7 +276,7 @@ Packager.prototype.development = function () {
 	// separate file and do the same with the sourcemaps themselves
 	if (!this.outJsFile) this.outJsFile = 'output.js';
 
-	bundle
+	this.applySorter(bundle)
 		.bundle()
 		.pipe(source(this.outJsFile))
 		.pipe(buffer())
@@ -288,7 +292,7 @@ Packager.prototype.production = function () {
 	var
 		bundle = browserify();
 	
-	this.setupBundle(bundle)
+	this.applySorter(this.setupBundle(bundle))
 		.plugin(collapser)
 		.bundle()
 		.pipe(source(this.outJsFile || 'output.js'))


### PR DESCRIPTION
## Issue
During incremental builds using `enyo-serve`, added packages aren't processed for stylesheets (or assets).

## Fix
Packages are identified by iterating the sorted JS dependencies. The sorter wasn't being ran on subsequent `bundle()`s so new packages were not identified. Previously, the sorter plugin was added in `setupBundle()` which is only called once for incremental builds. Moved the plugin def out of that method so it's called every run of `development()` or `production()`.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)