### PR TITLE
Use package.json options inside the server

### DIFF
--- a/lib/Server/index.js
+++ b/lib/Server/index.js
@@ -30,7 +30,10 @@ module.exports = function (opts) {
 		watcher.add(file);
 	}).on('done', function () {
 		if (!server) {
-			app.use(express.static(opts.webRoot));
+			
+			//get the webroot from the packager.
+			packager.processPackageJson();
+			app.use(express.static(packager.webRoot));
 			
 			server = app.listen(opts.port, addr, function () {
 				var addr = server.address();


### PR DESCRIPTION
There maybe more use cases, but webRoot was one of them that needs to be passed in through predefined configuration since we can specify build directory for epack.


Enyo-DCO-1.1-Signed-off-by: Derek Anderson <derek.anderson@lge.com>