### PR TITLE
ENYO-2012 Bug Fix: "egen init" can't install initial files in the specified directory

### DIFF
--- a/lib/Generator/index.js
+++ b/lib/Generator/index.js
@@ -155,6 +155,7 @@ Generator.prototype.init = function () {
 		generator = this,
 		rc;
 
+	tpl['cwd'] = this.package;
 	this.once('done', function () {
 		logger.log('info',
 			'The initialization is complete. Please note that this generator is in ALPHA state and ' +
@@ -195,11 +196,11 @@ Generator.prototype.init = function () {
 	logger.log('debug', 'writing .bowerrc file to package location');
 	fs.writeFile(path.join(this.package, '.bowerrc'), JSON.stringify(rc, null, 2), function (err) {
 		if (err) throw err;
-		generator.installBowerDeps();
+		generator.installBowerDeps(rc);
 	});
 };
 
-Generator.prototype.installBowerDeps = function () {
+Generator.prototype.installBowerDeps = function (rc) {
 
 	logger.log('info', 'installing bower dependencies');
 
@@ -350,7 +351,7 @@ Generator.prototype.installBowerDeps = function () {
 
 		bower
 			.commands
-			.install(libs, {save: generator.options.save, forceLatest: true})
+			.install(libs, {save: generator.options.save, forceLatest: true}, rc)
 			.on('log', function (msg) {
 
 				logger.log(msg.level != 'warn' ? 'debug' : 'warn', '%s%s => %s',

--- a/lib/Generator/index.js
+++ b/lib/Generator/index.js
@@ -110,7 +110,7 @@ function validateProjectDirectory (dir) {
 
 		// @todo Do we need to set the mode here or is 0777 ok?
 		// if either of these fail then we want the error to be uncaught for now
-		fs.makedirSync(dir);
+		fse.mkdirsSync(dir);
 		dir = fs.lstatSync(dir);
 	}
 


### PR DESCRIPTION
# Issue
(1)  no `makedirSync` function in fs module
(2) `egen init foo`  or `egen init foo/bar` does not work

# Fix
(1) replacing `fs.makedirSync()` with `fs-extra.mkdirsSync()`
   Why fs-extra?  `fs.mkdirSync()` doesn't support making multiple directories
(2) changing bower's working directory to pull components in the subdirectory.

# Test
`egen init foo` => initial files are installed in `foo` directory
`egen init foo/bar` => initial files are installed in `foo/bar` directory

Enyo-DCO-1.1-Signed-off-by Junil Kim <logyourself@gmail.com>