### PR TITLE
ENYO-2011 Changing the working directory to run browserify.bundle() in the specified directory

### DIFF
--- a/lib/Packager/index.js
+++ b/lib/Packager/index.js
@@ -87,6 +87,7 @@ function Packager (opts) {
 util.inherits(Packager, EventEmitter);
 
 Packager.prototype.run = function () {
+    if (process.cwd() !== this.package) {this.chDir = process.cwd(); process.chdir(this.package)};
 	// ordered array of packages as they were encountered for expos facto processing
 	this.packages = {order: []};
 
@@ -721,6 +722,6 @@ Packager.prototype.completeBuild = function () {
 	
 	logger.log('info', '%s build complete', this.devMode ? 'development' : 'production');
 	
-	output.on('end', function () { this.emit('done'); }.bind(this));
+	output.on('end', function () { if(this.chDir) { process.chdir(this.chDir); }; this.emit('done'); }.bind(this));
 	output.end();
 };


### PR DESCRIPTION
# Issue
If `epack` run with the directory path, `browserify.bundle()` fails.
 ex) epack foo

# Fix
`process.chdir()` to run `browserify.bundle()` properly in the directory specified.

# Comment
If there is a better solution, plz abandon this. 

Enyo-DCO-1.1-Signed-off-by Junil Kim <logyourself@gmail.com>