### PR TITLE
ENYO-2062: Disabled CSS restructuring during minification

### DIFF
--- a/lib/Packager/lib/process-style-stream/index.js
+++ b/lib/Packager/lib/process-style-stream/index.js
@@ -29,28 +29,28 @@ module.exports = ProcessStyleStream;
 
 function ProcessStyleStream (opts) {
 	if (!(this instanceof ProcessStyleStream)) return new ProcessStyleStream(opts);
-	
+
 	Transform.call(this, {objectMode: true});
-	
+
 	var base;
-	
+
 	opts = opts || {};
 	this.options = opts;
 	this._bundles = [];
-	
+
 	log.level(opts.logLevel);
-	
+
 	if (opts.lessPlugins) log.debug(opts.lessPlugins);
-	
+
 	if (opts.outCssFile) {
 		base = path.relative(
 			opts.outdir,
 			path.join(opts.outdir, path.dirname(opts.outCssFile))
 		);
 	}
-	
+
 	if (!base) base = opts.outdir;
-	
+
 	this._basePath = base;
 }
 
@@ -62,25 +62,25 @@ ProcessStyleStream.prototype._transform = function (bundle, nil, next) {
 };
 
 ProcessStyleStream.prototype._flush = function (done) {
-	
+
 	var
 		bundles = this._bundles,
 		stream = this;
-	
+
 	this._processBundles(bundles.slice(), function (err) {
-		
+
 		// as noted further below, this is due to a bug in Less...
 		if (err) return process.nextTick(function () {
 			utils.streamError(stream, 'failed to compile less: %s', err);
 		});
-		
+
 		log.info('done processing all bundle styles');
-		
+
 		bundles.forEach(function (bundle) { stream.push(bundle); });
 		stream.push(null);
 		done();
 	});
-	
+
 };
 
 ProcessStyleStream.prototype._processBundles = function (bundles, done) {
@@ -88,30 +88,30 @@ ProcessStyleStream.prototype._processBundles = function (bundles, done) {
 	var
 		stream = this,
 		bundle = bundles.shift();
-	
+
 	if (!bundle) return this._renderStyles(done);
-	
+
 	this._processBundle(bundle, function () {
 		stream._processBundles(bundles, done);
 	});
 };
 
 ProcessStyleStream.prototype._processBundle = function (bundle, done) {
-	
+
 	var
 		stream = this,
 		modules = bundle.modules,
 		order = bundle.order,
 		entries = [],
 		entry;
-	
+
 	log.info({bundle: bundle.name}, 'processing bundle style');
-	
+
 	for (var i = 0; i < order.length; ++i) {
 		entry = modules[order[i]];
 		if (entry.isPackage) {
 			if (entry.json.styles) {
-				
+
 				if (entry.styleEntries) {
 					log.info({bundle: bundle.name, module: entry.relName},
 						'package %s has previously been processed and has %d known %s; ' +
@@ -125,53 +125,53 @@ ProcessStyleStream.prototype._processBundle = function (bundle, done) {
 						style.module = entry; return style;
 					}));
 				} else {
-				
+
 					log.info({bundle: bundle.name, module: entry.relName},
 						'package %s has %d style %s',
 						entry.relName,
 						entry.json.styles.length,
 						entry.json.styles.length === 1 ? 'entry' : 'entries'
 					);
-				
+
 					entry.styleEntries = entry.json.styles.map(function (style) {
 						// note that we will remove the module property later to avoid circular
 						// references but is useful in debugging so we can associate output with
 						// the correct module and bundle; also for correct pathing
 						return {glob: style, module: entry};
 					});
-					
+
 					entries = entries.concat(entry.styleEntries);
 				}
 			}
 		}
 	}
-	
+
 	this._findFiles(entries.slice(), function () {
-		
+
 		log.debug({bundle: bundle.name}, 'done processing raw style content');
-		
+
 		// here we concatenate the ordered content from the files that were found
 		bundle.rawStyle = '';
-		
+
 		entries.forEach(function (entry) {
 			bundle.rawStyle += ((bundle.rawStyle ? '\n' : '') + entry.source);
 			// here is where we clean up the circular reference
 			delete entry.module;
 		});
-		
+
 		done();
 	});
 };
 
 ProcessStyleStream.prototype._findFiles = function (entries, done) {
-	
+
 	var
 		entry = entries.shift(),
 		stream = this,
 		file;
-	
+
 	if (!entry) return done();
-	
+
 	log.info({bundle: entry.module.bundleName, module: entry.module.relName},
 		'finding style files associated with module %s in bundle %s',
 		entry.module.relName,
@@ -184,17 +184,17 @@ ProcessStyleStream.prototype._findFiles = function (entries, done) {
 	if (!entry.sources) entry.sources = {};
 
 	if (isGlob(entry.glob)) {
-		
+
 		log.debug({bundle: entry.module.bundleName, module: entry.module.relName},
 			'determined that entry %s is a glob and must be re-scanned for new or missing files',
 			entry.glob
 		);
-		
+
 		glob(entry.glob, {cwd: entry.module.fullpath}, function (err, files) {
-			
+
 			var
 				i, idx, fp, known;
-			
+
 			if (err) utils.streamError(stream,
 				'failed to read files from glob entry %s from module %s in bundle %s: %s',
 				entry.glob,
@@ -202,19 +202,19 @@ ProcessStyleStream.prototype._findFiles = function (entries, done) {
 				entry.module.bundleName,
 				err
 			);
-			
+
 			log.debug({module: entry.module.relName, bundle: entry.module.bundleName},
 				'found %d files associated with style glob pattern %s',
 				files.length,
 				entry.glob
 			);
-			
+
 			// reset the combined source
 			entry.source = '';
-			
+
 			entry.files = files.map(function (e) { return path.join(entry.module.fullpath, e); });
 			files = entry.files.slice();
-			
+
 			(fp = function () {
 				var file = files.shift();
 				if (!file) {
@@ -234,7 +234,7 @@ ProcessStyleStream.prototype._findFiles = function (entries, done) {
 							}
 						});
 					}
-					
+
 					log.debug({module: entry.module.relName, bundle: entry.module.bundleName},
 						'done processing glob entry %s',
 						entry.glob
@@ -248,7 +248,7 @@ ProcessStyleStream.prototype._findFiles = function (entries, done) {
 				});
 			})();
 		});
-		
+
 	} else {
 
 		file = path.join(entry.module.fullpath, entry.glob);
@@ -270,14 +270,14 @@ ProcessStyleStream.prototype._findFiles = function (entries, done) {
 ProcessStyleStream.prototype._renderStyles = function (done) {
 
 	log.info('rendering final, cumulative styles');
-	
+
 	var
 		bundles = this._bundles,
 		opts = this.options,
 		src = '',
 		cfg = {},
 		minifier;
-	
+
 	bundles.forEach(function (bundle) {
 		if (bundle.rawStyle) {
 
@@ -289,27 +289,27 @@ ProcessStyleStream.prototype._renderStyles = function (done) {
 			src += tok + '\n';
 		}
 	});
-	
+
 	if (!src) {
 		log.info('no style to process');
 		return done();
 	}
-	
+
 	if (opts.lessPlugins) {
 		cfg.plugins = opts.lessPlugins.map(function (entry) {
-			
+
 			log.info('using plugin %s', entry.name);
-			
+
 			return new entry.plugin(entry.options);
 		});
 	}
-	
+
 	less
 		.render(src, cfg)
 		.then(function (compiled) {
-			
+
 			log.info('done compiling less');
-			
+
 			var css = compiled.css;
 			bundles.forEach(function (bundle) {
 
@@ -317,7 +317,7 @@ ProcessStyleStream.prototype._renderStyles = function (done) {
 					var
 						start = css.indexOf(bundle.token) + bundle.token.length + 1,
 						end = css.lastIndexOf(bundle.token);
-					
+
 					log.debug({bundle: bundle.name}, 'attempting to separate bundle style');
 
 					bundle.style = css.slice(start, end);
@@ -325,21 +325,22 @@ ProcessStyleStream.prototype._renderStyles = function (done) {
 						if (!minifier) {
 							minifier = new CleanCss({
 								processImport: false,
+								restructuring: false,	// Added because of: ENYO-2062
 								rebase: false,
 								roundingPrecision: -1,
 								keepSpecialComments: 0
 							});
 						}
-						
+
 						log.debug({bundle: bundle.name}, 'minifying style source');
-						
+
 						bundle.style = minifier.minify(bundle.style).styles;
 					}
-					
+
 					log.debug({bundle: bundle.name}, 'done separating style');
 				}
 			});
-			
+
 			done();
 		}, function (err) {
 			log.error('there was an error compiling less');
@@ -347,7 +348,7 @@ ProcessStyleStream.prototype._renderStyles = function (done) {
 			// is caught by them...
 			done(err);
 		});
-	
+
 };
 
 ProcessStyleStream.prototype._getFileContents = function (file, entry, done) {
@@ -356,12 +357,12 @@ ProcessStyleStream.prototype._getFileContents = function (file, entry, done) {
 		stream = this,
 		opts = this.options,
 		base = this._basePath;
-	
+
 	log.debug({file: file, bundle: entry.module.bundleName, module: entry.module.relName},
 		'attempting to stat and potentially read file %s',
 		file
 	);
-	
+
 	fs.stat(file, function (err, stat) {
 		if (err) {
 			if (opts.strict) {
@@ -379,24 +380,24 @@ ProcessStyleStream.prototype._getFileContents = function (file, entry, done) {
 				return done();
 			}
 		}
-		
+
 		var prev = entry.module.mtime[file];
-		
+
 		// update the mtime for the newly read file
 		entry.module.mtime[file] = stat.mtime.getTime();
-		
+
 		if (prev && prev == entry.module.mtime[file] && entry.sources[file]) {
 			log.debug({file: file, module: entry.module.relName, bundle: entry.module.bundleName},
 				'determined that the file is current'
 			);
-			
+
 			return done(entry.sources[file]);
 		}
-		
+
 		log.debug(
 			{file: path.relative(opts.cwd, file), module: entry.module.relName, bundle: entry.module.bundleName}, 'reading'
 		);
-		
+
 		fs.readFile(file, 'utf8', function (err, data) {
 			if (err) utils.streamError(stream,
 				'could not read style file %s from module %s in bundle %s',
@@ -404,11 +405,11 @@ ProcessStyleStream.prototype._getFileContents = function (file, entry, done) {
 				entry.module.relName,
 				entry.module.bundleName
 			);
-			
+
 			log.debug(
 				{file: path.relative(opts.cwd, file), module: entry.module.relName, bundle: entry.module.bundleName}, 'done reading'
 			);
-			
+
 			// we need to update all of the paths for the data
 			data = translateImportPaths(data, path.dirname(file), path.relative(opts.cwd, file), entry.module);
 			data = translateUrlPaths(data, file, entry.module, opts);
@@ -435,29 +436,29 @@ function translateImportPaths (text, base, file, pkg) {
 }
 
 function translateUrlPaths (data, file, entry, opts) {
-	
+
 	var
 		dir = path.dirname(file);
-	
+
 	return data.replace(/url\((?!(['"])?((http|data)\S+))(['"]?)(\S+?)\4\)/g, function (match, n0, n1, n2, n3, sub) {
-		
+
 		var
 			actual, ret;
-		
+
 		if (!utils.isAbsolute(sub)) {
 			actual = outfileSource(path.join(dir, sub), entry, opts);
 			ret = 'url(\'' + actual + '\')';
-			
+
 			if (log.debug()) log.debug(
 				{module: entry.relName, file: file, bundle: entry.bundleName},
 				'translating url from %s to %s',
 				match,
 				ret
 			);
-			
+
 			return ret;
 		}
-		
+
 		return match;
 	});
 }


### PR DESCRIPTION
…to prevent collapsing of incompatible selectors into one selector-set.

Also several blank-line whitespace cleanups.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens <blake.stephens@lge.com>