### PR TITLE
ENYO-2077: Bump resolution-independence.

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "nodegit": "^0.4.1",
     "nomnom": "^1.8.1",
     "osenv": "^0.1.2",
-    "resolution-independence": "0.0.1",
+    "resolution-independence": "0.0.2",
     "slash": "~1.0.0",
     "through2": "^0.6.3",
     "uglify-js": "^2.4.17",


### PR DESCRIPTION
### Issue
We had integrated fixes from the original resolution-independence plugin for Enyo 2.5 that fixed some latent issues (proper usage of `minUnitSize`, parsing of multiple-nested rules) and had created a new version (0.0.2) of the plugin, but had not bumped the version specified in `enyo-dev`.

### Fix
We have bumped the resolution-independence version specified by `enyo-dev` to `0.0.2`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>