### PR TITLE
ENYO-2062: Restructuring is no longer needed due to corrected CSS

### DIFF
--- a/lib/Packager/lib/process-style-stream/process-style-stream.js
+++ b/lib/Packager/lib/process-style-stream/process-style-stream.js
@@ -33,16 +33,16 @@ var
 
 function ProcessStyleStream (opts) {
 	if (!(this instanceof ProcessStyleStream)) return new ProcessStyleStream(opts);
-	
+
 	Transform.call(this, {objectMode: true});
-	
+
 	opts = opts || {};
 	this.options = opts;
 	this.bundles = [];
 	this.lessOnlyLess = !! opts.lessOnlyLess;
-	
+
 	log.level(opts.logLevel);
-	
+
 	var base;
 	if (opts.outCssFile) {
 		base = path.relative(opts.outdir, path.join(opts.outdir, path.dirname(opts.outCssFile)));
@@ -58,21 +58,21 @@ module.exports = ProcessStyleStream;
 var proto = ProcessStyleStream.prototype;
 
 proto._transform = function (bundle, nil, next) {
-	
+
 	log.info({bundle: bundle.name}, 'storing');
-	
+
 	this.bundles.push(bundle);
 	next();
 };
 
 proto._flush = function (done) {
-	
+
 	var
 		stream = this,
 		lessOnlyLess = this.lessOnlyLess;
-	
+
 	log.info('processing all %d bundles', this.bundles.length);
-	
+
 	this.findAllFiles().then(function (files) {
 		if (!files.length) {
 			log.debug('there were no files to process');
@@ -82,9 +82,9 @@ proto._flush = function (done) {
 			log.info('less-only-less is set and there are no less files to compile');
 			return;
 		}
-		
+
 		var toCompile;
-		
+
 		if (lessOnlyLess) {
 			log.info('compiling only the %d less files', file.lessFiles.length);
 			toCompile = files.lessFiles;
@@ -92,7 +92,7 @@ proto._flush = function (done) {
 			log.info('compiling all %d style files', files.length);
 			toCompile = files;
 		}
-		
+
 		return stream.compile(toCompile);
 	}).catch(function (e) {
 		utils.streamError(stream, 'There was an error processing the style:\n\t\t%s,%s', e);
@@ -109,15 +109,15 @@ proto.finish = Promise.method(function () {
 });
 
 proto.findAllFiles = function () {
-	
+
 	var
 		stream = this,
 		files = this.files = [],
 		lessOnlyLess = this.lessOnlyLess,
 		bundles = this.resolveBundles();
-	
+
 	log.info('resolving all files');
-	
+
 	return Promise.settle(bundles).then(function (results) {
 		results.forEach(function (result) {
 			result.value().forEach(function (entry) {
@@ -128,11 +128,11 @@ proto.findAllFiles = function () {
 				}
 			});
 		});
-		
+
 		if (log.debug()) log.debug(
 			files.map(function (file) { return file.fullpath; })
 		);
-		
+
 		return (stream.files = files);
 	});
 };
@@ -145,16 +145,16 @@ proto.resolveBundles = function () {
 };
 
 proto.resolveBundle = function (bundle) {
-	
+
 	var order, modules, stream, entry, resolving;
-	
+
 	order = bundle.order;
 	modules = bundle.modules;
 	stream = this;
 	resolving = [];
-	
+
 	log.info({bundle: bundle.name}, 'resolving bundle style files');
-	
+
 	for (var i = 0; i < order.length; ++i) {
 		entry = modules[order[i]];
 		if (entry.isPackage) {
@@ -168,7 +168,7 @@ proto.resolveBundle = function (bundle) {
 			}
 		}
 	}
-	
+
 	return Promise.settle(resolving).then(function (results) {
 		var files = [];
 		results.forEach(function (result) {
@@ -179,17 +179,17 @@ proto.resolveBundle = function (bundle) {
 };
 
 proto.resolve = Promise.method(function (globish, entry, bundle) {
-	
+
 	var stream = this, fp;
-	
+
 	if (log.debug()) log.debug({module: entry.relName, bundle: bundle.name}, 'attempting to ' +
 			'resolve style entry %s', globish);
-	
+
 	if (isGlob(globish)) {
-		
+
 		if (log.debug()) log.debug({module: entry.relName, bundle: bundle.name}, 'determined that ' +
 			' %s is a glob pattern, resolving matches', globish);
-		
+
 		return glob(globish, {cwd: entry.fullpath})
 			.then(function (files) {
 				var reading = files.map(function (file) {
@@ -214,13 +214,13 @@ proto.resolve = Promise.method(function (globish, entry, bundle) {
 				return [];
 			});
 	} else {
-		
+
 		if (log.debug()) log.debug({module: entry.relName, bundle: bundle.name}, 'determined that ' +
 			'%s is a direct file reference, resolving as a file', globish);
-		
+
 		fp = path.join(entry.fullpath, globish);
 		entry.styleEntries.push(fp);
-		
+
 		return this.resolveContents({fullpath: fp, entry: entry, bundle: bundle})
 			.then(function (file) {
 				return [file];
@@ -230,13 +230,13 @@ proto.resolve = Promise.method(function (globish, entry, bundle) {
 				return [];
 			});
 	}
-	
+
 });
 
 proto.resolveContents = function (file) {
-	
+
 	var opts = this.options;
-	
+
 	return readFile(file.fullpath, 'utf8').then(function (contents) {
 		if (path.extname(file.fullpath) == '.less') file.isLess = true;
 		contents = translateImportPaths(contents, path.dirname(file.fullpath), path.relative(opts.cwd, file.fullpath), file.entry);
@@ -248,28 +248,28 @@ proto.resolveContents = function (file) {
 
 proto.compile = Promise.method(function (files) {
 	log.debug('compiling %d files via the less compiler', files.length);
-	
+
 	var src, cfg, opts, stream;
-	
+
 	stream = this;
 	opts = this.options;
 	src = '';
 	cfg = {};
-	
+
 	if (opts.lessPlugins) {
 		cfg.plugins = opts.lessPlugins.map(function (entry) {
 			log.info('using Less pluging %s', entry.name);
 			return new entry.plugin(entry.options || {});
 		});
 	}
-	
+
 	files.forEach(function (file) {
 		file.token = util.format('/*%s*/', file.fullpath);
 		src += '\n' + file.token;
 		src += file.contents;
 		src += file.token + '\n';
 	});
-	
+
 	return lessc.render(src, cfg)
 		.then(function (compiled) {
 			return stream.deconstruct(compiled.css, files);
@@ -280,30 +280,29 @@ proto.compile = Promise.method(function (files) {
 });
 
 proto.postProcess = Promise.method(function () {
-	
+
 	log.info('post-processing style');
-	
+
 	var files, opts, minify, minifier, bundles;
-	
+
 	opts = this.options;
 	minify = opts.minifyCss || opts.production;
 	files = this.files;
 	bundles = this.bundles;
-	
+
 	if (minify) {
 		minifier = new CleanCss({
 			processImport: false,
 			rebase: false,
 			roundingPrecision: -1,
-			keepSpecialComments: 0,
-			restructuring: false // Added because of: ENYO-2062
+			keepSpecialComments: 0
 		});
 	}
-	
+
 	files.forEach(function (file) {
 		file.bundle.style += file.contents;
 	});
-	
+
 	if (minify) bundles.forEach(function (bundle) {
 		if (bundle.style) bundle.style = minifier.minify(bundle.style).styles;
 	});
@@ -337,29 +336,29 @@ function translateImportPaths (text, base, file, pkg) {
 }
 
 function translateUrlPaths (data, file, entry, opts) {
-	
+
 	var
 		dir = path.dirname(file);
-	
+
 	return data.replace(/url\((?!(['"])?((http|data)\S+))(['"]?)(\S+?)\4\)/g, function (match, n0, n1, n2, n3, sub) {
-		
+
 		var
 			actual, ret;
-		
+
 		if (!utils.isAbsolute(sub)) {
 			actual = outfileSource(path.join(dir, sub), entry, opts);
 			ret = 'url(\'' + actual + '\')';
-			
+
 			if (log.debug()) log.debug(
 				{module: entry.relName, file: file, bundle: entry.bundleName},
 				'translating url from %s to %s',
 				match,
 				ret
 			);
-			
+
 			return ret;
 		}
-		
+
 		return match;
 	});
 }


### PR DESCRIPTION
Relevant details: https://developer.mozilla.org/en-US/docs/Web/CSS/:fullscreen
Also, "several" whitespace changes.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens <blake.stephens@lge.com>