### PR TITLE
ENYO-2145: Bump resolution-independence version.

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -174,6 +174,8 @@ function lessPlugins (opts) {
 				logger.fatal(err, 'could not find the requested Less plugin, ' + e.name);
 				process.exit(-1);
 			}
+
+			return e;
 		});
 	}
 	

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "minimist": "^1.1.1",
     "nomnom": "^1.8.1",
     "osenv": "^0.1.2",
-    "resolution-independence": "^0.0.2",
+    "resolution-independence": "^0.0.3",
     "slash": "~1.0.0",
     "through2": "^0.6.3",
     "uglify-js": "^2.4.17",


### PR DESCRIPTION
### Issue
Some updates were made to the `resolution-independence` plugin.

### Fix
We bumped the version of the dependency.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>