### PR TITLE
Fix for: ENYO-2609

### DIFF
--- a/lib/Packager/lib/outfile-source.js
+++ b/lib/Packager/lib/outfile-source.js
@@ -1,7 +1,8 @@
 'use strict';
 
 var
-	path = require('path');
+	path = require('path'),
+	url = require('url');
 
 var
 	slash = require('slash');
@@ -27,7 +28,7 @@ module.exports = function (file, entry, opts, isOutfile) {
 			file = path.resolve(opts.cwd, file);
 		}
 		if (!isOutfile && libMode && (libp = utils.assetRootFor(entry.libName, opts))) {
-			ret = path.join(libp, entry.libName, file.slice(entry.lib.length));
+			ret = url.resolve(libp, path.join(entry.libName, file.slice(entry.lib.length)));
 		} else ret = path.join(entry.libName, file.slice(entry.lib.length));
 	} else {
 		if (utils.isAbsolute(file)) {
@@ -38,6 +39,5 @@ module.exports = function (file, entry, opts, isOutfile) {
 	if (log.debug()) log.debug({module: entry.relName},
 		'outfile from %s to %s', path.relative(opts.cwd, file), ret
 	);
-
 	return slash(ret);
 };


### PR DESCRIPTION
Relative URI's using web URL's with the -Z option were not preserving the double '//'. 

Enyo-DCO-1.1-Signed-Off-By: Cole Davis (cole.davis@lge.com)