### PR TITLE
ENYO-3096: Library builds fail on package.json files without main/ind…

### DIFF
--- a/lib/Packager/lib/recurse-library.js
+++ b/lib/Packager/lib/recurse-library.js
@@ -31,7 +31,16 @@ function readdir (dir, opts) {
 						return fs.readJsonAsync(pkg).then(function (json) {
 							if (opts.wip || !json.wip) {
 								return readdir(file, opts).then(function (files) {
-									files.unshift(file);
+									if (!json.main && files.indexOf(path.join(file, 'index.js'))>-1) {
+										json.main = 'index.js';
+									}
+									if(json.main){
+										var mainIndex = files.indexOf(path.join(file, json.main));
+										if (mainIndex>-1) {
+											files.splice(mainIndex, 1);
+										}
+										files.unshift(file);
+									}
 									return files;
 								});
 							}


### PR DESCRIPTION
…ex.js
Enyo-DCO-1.1-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>