### PR TITLE
ENYO-3107: enyo-dev syntax error preventing request creation

### DIFF
--- a/lib/Packager/lib/pack-bundle-stream/lib/request.js
+++ b/lib/Packager/lib/pack-bundle-stream/lib/request.js
@@ -3,7 +3,7 @@
 (function () {
 	if (!scope.Promise) throw new Error('No Promise implementation found, please provide a polyfill for this platform');
 	var   request = enyo.request || (defineProperty(enyo, 'request', {value: enyoRequest}) && enyo.request)
-		, pending = enyo.__pendingRequests__ || (defineProperty(enyo, '__pendingRequests__', {value: {}}) && enyo.pending)
+		, pending = enyo.__pendingRequests__ || (defineProperty(enyo, '__pendingRequests__', {value: {}}) && enyo.__pendingRequests__)
 		, Request = enyo.__Request__;
 	
 	if (!Request) {


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: Jason Robitaille <jason.robitaille@lge.com>