### PR TITLE
Fixes ENYO-3216

### DIFF
--- a/lib/Packager/Packager.js
+++ b/lib/Packager/Packager.js
@@ -110,7 +110,7 @@ proto.buildLibrary = function (opts) {
 
 	initial = {
 		path: opts.package,
-		entry: true,
+		entry: false,
 		lib: opts.package,
 		libName: opts.name,
 		name: opts.name,


### PR DESCRIPTION
There doesn't appear to be any known reason to automatically run the
root module for a library by default so we'll set that to false
initially and allow it to be overridden by the library if necessary.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)