### PR TITLE
ENYO-4354 - prepend module.exports to json file dependencies

### DIFF
--- a/lib/Packager/lib/pack-bundle-stream/lib/BundleManifest.js
+++ b/lib/Packager/lib/pack-bundle-stream/lib/BundleManifest.js
@@ -6,6 +6,7 @@ var
 
 var
 	MODULE_START     = '[function (module,exports,global,require,request){\n',
+	MODULE_EXPORTS   = 'module.exports=',
 	MODULE_BODY_END  = '\n}',
 	MODULE_END       = ']',
 	MODULE_MAP_START = ',{',
@@ -35,14 +36,21 @@ function BundleManifest (bundler, bundle, opts, map, line) {
 var proto = BundleManifest.prototype;
 
 proto.insert = function (entry) {
-	var bundler, manifest, src, map, mapSource, modules, section, alias, own;
+	var bundler, manifest, src, map, mapSource, modules, section, alias, own, main;
 	manifest = this;
 	bundler = this.bundler;
 	modules = this.modules;
 	section = {};
 	own = this.bundle;
 	map = this.map;
-	src = MODULE_START + entry.contents + MODULE_BODY_END;
+
+	main = entry.isPackage ? entry.main : entry.relPath;
+	if (/\.json$/i.test(main)) {
+		src = MODULE_START + MODULE_EXPORTS + entry.contents + MODULE_BODY_END;
+	} else {
+		src = MODULE_START + entry.contents + MODULE_BODY_END;
+	}
+
 	if (this.log()) this.log({module: entry.relName}, 'inserting module into manifest');
 	if (map) {
 		if (this.log()) this.log({module: entry.relName}, 'adding sourcemap entry at line %d', this.line);


### PR DESCRIPTION
Support requiring JSON files by prepending a `module.exports`.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)