### PR TITLE
Allows require of JSON file in module required by another module

### DIFF
--- a/lib/Packager/lib/pack-bundle-stream/lib/BundleManifest.js
+++ b/lib/Packager/lib/pack-bundle-stream/lib/BundleManifest.js
@@ -44,7 +44,7 @@ proto.insert = function (entry) {
 	own = this.bundle;
 	map = this.map;
 
-	main = entry.isPackage ? entry.main : entry.relPath;
+	main = entry.isPackage ? entry.main : entry.path;
 	if (/\.json$/i.test(main)) {
 		src = MODULE_START + MODULE_EXPORTS + entry.contents + MODULE_BODY_END;
 	} else {

--- a/lib/Packager/lib/pack-bundle-stream/lib/BundleManifest.js
+++ b/lib/Packager/lib/pack-bundle-stream/lib/BundleManifest.js
@@ -46,7 +46,7 @@ proto.insert = function (entry) {
 
 	main = entry.isPackage ? entry.main : entry.path;
 	if (/\.json$/i.test(main)) {
-		src = MODULE_START + MODULE_EXPORTS + entry.contents + MODULE_BODY_END;
+		src = MODULE_START + MODULE_EXPORTS + entry.contents.replace(/\u2028/g, '\\u2028').replace(/\u2029/g, '\\u2029') + MODULE_BODY_END;
 	} else {
 		src = MODULE_START + entry.contents + MODULE_BODY_END;
 	}


### PR DESCRIPTION
Enyo-DCO-1.1-Signed-off-by: Doug Reeder (reeder.29@gmail.com)

The previous PR (thanks for the quick action!) allows require to work on JSON files
appinfo = require('../appinfo.json’)

and modules that require a JSON file 
entities = require('../node_modules/entities')

but not modules that require a module that requires a JSON file
commonmark = require('../node_modules/commonmark')


This PR allows the third scenario to work.